### PR TITLE
update version check for seqkit, csvtk, and gfa_connector

### DIFF
--- a/bin/shovill
+++ b/bin/shovill
@@ -39,7 +39,7 @@ my $t0 = time;                # basetime to measure running duration
 my %ASSEMBLER = ( map { $_ => 1 } qw(spades skesa megahit velvet) );
 
 my %VERSION = (
-  'seqkit'      => 'seqkit 2>&1 | grep Version',
+  'seqkit'      => 'seqkit version',
   'csvtk'       => 'csvtk --version 2>&1',
   'kmc'         => 'kmc -h 2>&1 | grep KMC',
   'trimmomatic' => 'trimmomatic -version 2>&1 | grep -v _JAVA',

--- a/bin/shovill
+++ b/bin/shovill
@@ -39,15 +39,15 @@ my $t0 = time;                # basetime to measure running duration
 my %ASSEMBLER = ( map { $_ => 1 } qw(spades skesa megahit velvet) );
 
 my %VERSION = (
-  'seqkit'      => 'seqkit --versiom 2>&1',
-  'csvtk'       => 'csvtk --versiom 2>&1',
+  'seqkit'      => 'seqkit 2>&1 | grep Version',
+  'csvtk'       => 'csvtk --version 2>&1',
   'kmc'         => 'kmc -h 2>&1 | grep KMC',
   'trimmomatic' => 'trimmomatic -version 2>&1 | grep -v _JAVA',
   'lighter'     => 'lighter -v 2>&1',
   'flash'       => 'flash --version 2>&1 | grep FLASH',
   'spades.py'   => 'spades.py  --version 2>&1',
   'skesa'       => 'skesa --version 2>&1 | grep SKESA',
-  'gfa_connector' => 'gfa_connector --version 2>&1 | grep gfa_connector',
+  'gfa_connector' => 'gfa_connector --version 2>&1 | grep "gfa_connector [[:digit:]].[[:digit:]].[[:digit:]]"',
   'megahit'     => 'megahit --version 2>&1',
   'megahit_toolkit' => 'megahit_toolkit dumpversion 2>&1',
   'velveth'     => 'velveth 2>&1 | grep Version',


### PR DESCRIPTION
I noticed some oddities in shovill's `--check` option.

- ~~I don't think `seqkit` has a `--version` flag, but the version is listed when you run `seqkit` with no other subcommands or options~~
  - EDIT: `seqkit version` subcommand does exist!
- `csvtk --versiom` changed to `csvtk --version`
- Updated grep for `gfa_connector` to specifically find the line with version digits `x.x.x`

Before changes:
```
# shovill --check
[shovill] Using bwa - /usr/local/bin/bwa | Version: 0.7.19-r1273
[shovill] Using csvtk - /usr/local/bin/csvtk | Error: unknown flag: --versiom
[shovill] Using flash - /usr/local/bin/flash | FLASH v1.2.11
[shovill] Using gfa_connector - /usr/local/bin/gfa_connector | gfa_connector --version 
[shovill] Using java - /usr/bin/java | openjdk version "25.0.1" 2025-10-21
[shovill] Using kmc - /kmc/bin/kmc | K-Mer Counter (KMC) ver. 3.2.4 (2024-02-09)
[shovill] Using lighter - /usr/local/bin/lighter | Lighter v1.1.3
[shovill] Using megahit - /usr/local/bin/megahit | MEGAHIT v1.2.9
[shovill] Using megahit_toolkit - /usr/local/bin/megahit_toolkit | v1.2.9
[shovill] Using pilon - /usr/local/bin/pilon | Pilon version 1.24 Thu Jan 28 13:00:45 2021 -0500
[shovill] Using samclip - /usr/local/bin/samclip | samclip 0.4.0
[shovill] Using samtools - /usr/local/bin/samtools | Version: 1.16.1 (using htslib 1.16)
[shovill] Using seqkit - /usr/local/bin/seqkit | Error: unknown flag: --versiom
[shovill] Using skesa - /usr/local/bin/skesa | SKESA 2.5.1
[shovill] Using spades.py - /usr/local/bin/spades.py | SPAdes genome assembler v3.15.5
[shovill] Using trimmomatic - /usr/local/bin/trimmomatic | 0.40
[shovill] Using velvetg - /usr/local/bin/velvetg | Version 1.2.10
[shovill] Using velveth - /usr/local/bin/velveth | Version 1.2.10
```

After changes:
```
# shovill --check
[shovill] Using bwa - /usr/local/bin/bwa | Version: 0.7.19-r1273
[shovill] Using csvtk - /usr/local/bin/csvtk | csvtk v0.36.0
[shovill] Using flash - /usr/local/bin/flash | FLASH v1.2.11
[shovill] Using gfa_connector - /usr/local/bin/gfa_connector | gfa_connector 1.1.1
[shovill] Using java - /usr/bin/java | openjdk version "25.0.1" 2025-10-21
[shovill] Using kmc - /kmc/bin/kmc | K-Mer Counter (KMC) ver. 3.2.4 (2024-02-09)
[shovill] Using lighter - /usr/local/bin/lighter | Lighter v1.1.3
[shovill] Using megahit - /usr/local/bin/megahit | MEGAHIT v1.2.9
[shovill] Using megahit_toolkit - /usr/local/bin/megahit_toolkit | v1.2.9
[shovill] Using pilon - /usr/local/bin/pilon | Pilon version 1.24 Thu Jan 28 13:00:45 2021 -0500
[shovill] Using samclip - /usr/local/bin/samclip | samclip 0.4.0
[shovill] Using samtools - /usr/local/bin/samtools | Version: 1.16.1 (using htslib 1.16)
[shovill] Using seqkit - /usr/local/bin/seqkit | Version: 2.12.0
[shovill] Using skesa - /usr/local/bin/skesa | SKESA 2.5.1
[shovill] Using spades.py - /usr/local/bin/spades.py | SPAdes genome assembler v3.15.5
[shovill] Using trimmomatic - /usr/local/bin/trimmomatic | 0.40
[shovill] Using velvetg - /usr/local/bin/velvetg | Version 1.2.10
[shovill] Using velveth - /usr/local/bin/velveth | Version 1.2.10
```

FYI ^ These test commands were ran inside a docker image that I'm working on for shovill v1.4.2 for StaPH-B. This is not from the conda/bioconda environment. I haven't tested in that environment, but assume it would work fine there.