### PR TITLE
Adjust minimum RAM to enable usage with 8 Gb

### DIFF
--- a/bin/shovill
+++ b/bin/shovill
@@ -24,17 +24,17 @@ my $ADAPTERS = "$APPDIR/db/trimmomatic.fa"; # hard-code this for Conda etc.
 my $LOGTMP = File::Temp->new();
 my $LOGFILE = $LOGTMP->filename;
 
-my $MIN_K = 31;               # sensible minimum, although prefer higher
-my $MAX_K = 127;              # maximum for most assemblers
-my $KMER_READ_FRAC = 0.75;    # ensure max kmer below this prop of read length
-my $MIN_BQ = 3;               # for trimming and stats and pilon
-my $MIN_MQ = 60;              # for pilon
-my $MIN_FLASH_OVERLAP = 20;   # for stitching
-my $MIN_RAM_GB = 8;           # for all tools
+my $MIN_K = 31;                  # sensible minimum, although prefer higher
+my $MAX_K = 127;                 # maximum for most assemblers
+my $KMER_READ_FRAC = 0.75;       # ensure max kmer below this prop of read length
+my $MIN_BQ = 3;                  # for trimming and stats and pilon
+my $MIN_MQ = 60;                 # for pilon
+my $MIN_FLASH_OVERLAP = 20;      # for stitching
+my $MIN_RAM_GB = int(8 / 1.024); # for all tools
 my $TRIMOPT = "ILLUMINACLIP:$ADAPTERS:1:30:11 LEADING:$MIN_BQ TRAILING:$MIN_BQ MINLEN:30 TOPHRED33";
 
-my @CMDLINE = ($0, @ARGV);    # save this for printing to log later
-my $t0 = time;                # basetime to measure running duration
+my @CMDLINE = ($0, @ARGV);       # save this for printing to log later
+my $t0 = time;                   # basetime to measure running duration
 
 my %ASSEMBLER = ( map { $_ => 1 } qw(spades skesa megahit velvet) );
 


### PR DESCRIPTION
Suggesting to calculate actual memory size and round down, to encompass laptops with 8 Gb ram.

Should resolve #195 